### PR TITLE
refactor(automation): move automation logic to internal/core layer (#14)

### DIFF
--- a/internal/core/automation/automation.go
+++ b/internal/core/automation/automation.go
@@ -8,25 +8,6 @@ import (
 	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
-type AutomationData struct {
-	SystemDServices []SystemDUnit `json:"systemd_services"`
-	SystemDTimers   []SystemDUnit `json:"systemd_timers"`
-	UserCronjobs    []Cronjob     `json:"user_cronjobs"`
-	SystemCronjobs  []Cronjob     `json:"system_cronjobs"`
-}
-type SystemDUnit struct {
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	Content     string `json:"content"`
-	UnitType    string `json:"unit_type"` ////saare service, timer and target available ere
-	IsEnabled   bool   `json:"is_enabled"`
-	IsActive    bool   `json:"is_active"`
-}
-type Cronjob struct {
-	Path    string `json:"path"`
-	Content string `json:"content"`
-	Type    string `json:"type"` //.//user, system, cron_d
-}
 type AutomationManager struct {
 	username string
 }
@@ -40,14 +21,14 @@ func NewAutomationManager() *AutomationManager {
 		username: username,
 	}
 }
-func (am *AutomationManager) DetectAutomation() (*AutomationData, error) {
+func (am *AutomationManager) DetectAutomation() (*domain.AutomationData, error) {
 	fmt.Println("Detecting automation files...")
 	
-	data := &AutomationData{
-		SystemDServices: make([]SystemDUnit, 0),
-		SystemDTimers:   make([]SystemDUnit, 0),
-		UserCronjobs:    make([]Cronjob, 0),
-		SystemCronjobs:  make([]Cronjob, 0),
+	data := &domain.AutomationData{
+		SystemDServices: make([]domain.SystemDUnit, 0),
+		SystemDTimers:   make([]domain.SystemDUnit, 0),
+		UserCronjobs:    make([]domain.Cronjob, 0),
+		SystemCronjobs:  make([]domain.Cronjob, 0),
 	}
 	
 	systemdServices, systemdTimers, err := am.detectSystemDUnits()

--- a/internal/core/automation/backup.go
+++ b/internal/core/automation/backup.go
@@ -4,10 +4,11 @@ import (
 	"archive/tar"
 	"fmt"
 	"path/filepath"
-	"strings"
+
+	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
-func (am *AutomationManager) BackupAutomation(data *AutomationData, tarWriter *tar.Writer) error {
+func (am *AutomationManager) BackupAutomation(data *domain.AutomationData, tarWriter *tar.Writer) error {
 	fmt.Println("Adding automation files to backup...")
 	
 	for _, service := range data.SystemDServices {
@@ -51,60 +52,8 @@ func (am *AutomationManager) addFileToTarball(originalPath, content, tarballPref
 	
 	return nil
 }
-///TODO(@jaadu): IMPROVE THE RESTORE LOGIC AND RESTORATION COMMAND
-func (am *AutomationManager) GenerateRestorationCommands(data *AutomationData) []string {
-	var commands []string
-	if len(data.SystemDServices) > 0 || len(data.SystemDTimers) > 0 {
-		commands = append(commands, "echo 'Restoring SystemD units...'")
-		
-		for _, service := range data.SystemDServices {
-			commands = append(commands, fmt.Sprintf("sudo cp automation/systemd/%s %s", 
-				filepath.Base(service.Path), service.Path))
-		}
-		for _, timer := range data.SystemDTimers {
-			commands = append(commands, fmt.Sprintf("sudo cp automation/systemd/%s %s", 
-				filepath.Base(timer.Path), timer.Path))
-		}
-		
 
-
-		// Reload SystemD daemon
-		commands = append(commands, "sudo systemctl daemon-reload")
-		// Enable and start services
-		for _, service := range data.SystemDServices {
-			if service.UnitType == "service" {
-				commands = append(commands, fmt.Sprintf("sudo systemctl enable --now %s || true", 
-					strings.TrimSuffix(service.Name, ".service")))
-			}
-		}
-		// Enable and start timers
-		for _, timer := range data.SystemDTimers {
-			commands = append(commands, fmt.Sprintf("sudo systemctl enable --now %s || true", 
-				strings.TrimSuffix(timer.Name, ".timer")))
-		}
-	}
-	if len(data.UserCronjobs) > 0 || len(data.SystemCronjobs) > 0 {
-		commands = append(commands, "echo 'Restoring cronjobs...'")
-		for _, cronjob := range data.UserCronjobs {
-			if cronjob.Type == "user" {
-				commands = append(commands, fmt.Sprintf("crontab automation/cron/%s || true", 
-					filepath.Base(cronjob.Path)))
-			}
-		}
-		for _, cronjob := range data.SystemCronjobs {
-			if cronjob.Type == "system" {
-				commands = append(commands, fmt.Sprintf("sudo cp automation/cron/%s %s", 
-					filepath.Base(cronjob.Path), cronjob.Path))
-			} else if cronjob.Type == "cron_d" {
-				commands = append(commands, fmt.Sprintf("sudo cp automation/cron/%s %s", 
-					filepath.Base(cronjob.Path), cronjob.Path))
-			}
-		}
-	}
-	
-	return commands
-}
-func (am *AutomationManager) ValidateAutomationData(data *AutomationData) error {
+func (am *AutomationManager) ValidateAutomationData(data *domain.AutomationData) error {
 	unitNames := make(map[string]bool)
 	
 	for _, service := range data.SystemDServices {

--- a/internal/core/automation/restore.go
+++ b/internal/core/automation/restore.go
@@ -1,0 +1,63 @@
+package automation
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/mdgspace/sysreplicate/internal/domain"
+)
+
+///TODO(@jaadu): IMPROVE THE RESTORE LOGIC AND RESTORATION COMMAND
+func (am *AutomationManager) GenerateRestorationCommands(data *domain.AutomationData) []string {
+	var commands []string
+	if len(data.SystemDServices) > 0 || len(data.SystemDTimers) > 0 {
+		commands = append(commands, "echo 'Restoring SystemD units...'")
+		
+		for _, service := range data.SystemDServices {
+			commands = append(commands, fmt.Sprintf("sudo cp automation/systemd/%s %s", 
+				filepath.Base(service.Path), service.Path))
+		}
+		for _, timer := range data.SystemDTimers {
+			commands = append(commands, fmt.Sprintf("sudo cp automation/systemd/%s %s", 
+				filepath.Base(timer.Path), timer.Path))
+		}
+		
+
+
+		// Reload SystemD daemon
+		commands = append(commands, "sudo systemctl daemon-reload")
+		// Enable and start services
+		for _, service := range data.SystemDServices {
+			if service.UnitType == "service" {
+				commands = append(commands, fmt.Sprintf("sudo systemctl enable --now %s || true", 
+					strings.TrimSuffix(service.Name, ".service")))
+			}
+		}
+		// Enable and start timers
+		for _, timer := range data.SystemDTimers {
+			commands = append(commands, fmt.Sprintf("sudo systemctl enable --now %s || true", 
+				strings.TrimSuffix(timer.Name, ".timer")))
+		}
+	}
+	if len(data.UserCronjobs) > 0 || len(data.SystemCronjobs) > 0 {
+		commands = append(commands, "echo 'Restoring cronjobs...'")
+		for _, cronjob := range data.UserCronjobs {
+			if cronjob.Type == "user" {
+				commands = append(commands, fmt.Sprintf("crontab automation/cron/%s || true", 
+					filepath.Base(cronjob.Path)))
+			}
+		}
+		for _, cronjob := range data.SystemCronjobs {
+			if cronjob.Type == "system" {
+				commands = append(commands, fmt.Sprintf("sudo cp automation/cron/%s %s", 
+					filepath.Base(cronjob.Path), cronjob.Path))
+			} else if cronjob.Type == "cron_d" {
+				commands = append(commands, fmt.Sprintf("sudo cp automation/cron/%s %s", 
+					filepath.Base(cronjob.Path), cronjob.Path))
+			}
+		}
+	}
+	
+	return commands
+}

--- a/internal/core/automation/scanner.go
+++ b/internal/core/automation/scanner.go
@@ -9,9 +9,9 @@ import (
 	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
-func (am *AutomationManager) detectSystemDUnits() ([]SystemDUnit, []SystemDUnit, error) {
-	var services []SystemDUnit
-	var timers []SystemDUnit
+func (am *AutomationManager) detectSystemDUnits() ([]domain.SystemDUnit, []domain.SystemDUnit, error) {
+	var services []domain.SystemDUnit
+	var timers []domain.SystemDUnit
 
 	if _, err := os.Stat(domain.SystemdDirPath); os.IsNotExist(err) {
 		fmt.Printf("SystemD directory %s does not exist, skipping SystemD detection\n", domain.SystemdDirPath)
@@ -38,7 +38,7 @@ func (am *AutomationManager) detectSystemDUnits() ([]SystemDUnit, []SystemDUnit,
 		}
 		isEnabled, isActive := am.getSystemDUnitStatus(unitName)
 
-		unit := SystemDUnit{
+		unit := domain.SystemDUnit{
 			Name:      unitName,
 			Path:      path,
 			Content:   content,
@@ -67,9 +67,9 @@ func (am *AutomationManager) detectSystemDUnits() ([]SystemDUnit, []SystemDUnit,
 }
 
 // ///detectCronjobs scans for cron job files
-func (am *AutomationManager) detectCronjobs() ([]Cronjob, []Cronjob, error) {
-	var userCronjobs []Cronjob
-	var systemCronjobs []Cronjob
+func (am *AutomationManager) detectCronjobs() ([]domain.Cronjob, []domain.Cronjob, error) {
+	var userCronjobs []domain.Cronjob
+	var systemCronjobs []domain.Cronjob
 
 	userCronPath := fmt.Sprintf(domain.UserCronTemplatePath, am.username)
 	if content, err := am.readFileContent(userCronPath); err == nil {
@@ -83,7 +83,7 @@ func (am *AutomationManager) detectCronjobs() ([]Cronjob, []Cronjob, error) {
 		}
 
 		if len(filteredLines) > 0 {
-			userCronjobs = append(userCronjobs, Cronjob{
+			userCronjobs = append(userCronjobs, domain.Cronjob{
 				Path:    userCronPath,
 				Content: content,
 				Type:    "user",
@@ -122,7 +122,7 @@ func (am *AutomationManager) detectCronjobs() ([]Cronjob, []Cronjob, error) {
 					cronType = "cron_d"
 				}
 
-				systemCronjobs = append(systemCronjobs, Cronjob{
+				systemCronjobs = append(systemCronjobs, domain.Cronjob{
 					Path:    cronPath,
 					Content: content,
 					Type:    cronType,
@@ -139,7 +139,7 @@ func (am *AutomationManager) dirExists(path string) bool {
 	return err == nil && info.IsDir()
 }
 
-func (am *AutomationManager) GetAutomationSummary(data *AutomationData) string {
+func (am *AutomationManager) GetAutomationSummary(data *domain.AutomationData) string {
 	var summary strings.Builder
 
 	summary.WriteString("Automation Detection Summary:\n")

--- a/internal/core/backup/unified_backup.go
+++ b/internal/core/backup/unified_backup.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/mdgspace/sysreplicate/internal/domain"
-	"github.com/mdgspace/sysreplicate/system/automation"
+	"github.com/mdgspace/sysreplicate/internal/core/automation"
 	"github.com/mdgspace/sysreplicate/system/output"
 	"github.com/mdgspace/sysreplicate/internal/platform"
 )
@@ -24,7 +24,7 @@ type UnifiedBackupData struct {
 	EncryptedKeys map[string]output.EncryptedKey `json:"encrypted_keys"`
 	Dotfiles      []output.Dotfile            `json:"dotfiles"`
 	Packages      map[string][]string         `json:"packages"`
-	Automation    *automation.AutomationData `json:"automation"`
+	Automation    *domain.AutomationData `json:"automation"`
 	EncryptionKey []byte                      `json:"encryption_key"`
 	Distro        string                      `json:"distro"`
 	BaseDistro    string                      `json:"base_distro"`

--- a/internal/domain/automation.go
+++ b/internal/domain/automation.go
@@ -1,0 +1,21 @@
+package domain
+
+type AutomationData struct {
+	SystemDServices []SystemDUnit `json:"systemd_services"`
+	SystemDTimers   []SystemDUnit `json:"systemd_timers"`
+	UserCronjobs    []Cronjob     `json:"user_cronjobs"`
+	SystemCronjobs  []Cronjob     `json:"system_cronjobs"`
+}
+type SystemDUnit struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Content     string `json:"content"`
+	UnitType    string `json:"unit_type"` ////saare service, timer and target available ere
+	IsEnabled   bool   `json:"is_enabled"`
+	IsActive    bool   `json:"is_active"`
+}
+type Cronjob struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	Type    string `json:"type"` //.//user, system, cron_d
+}

--- a/system/output/script.go
+++ b/system/output/script.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mdgspace/sysreplicate/system/automation"
+	"github.com/mdgspace/sysreplicate/internal/core/automation"
 	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
 // generateInstallScript creates a shell script to install all packages for the given distro.
 // Returns an error if the script cannot be created or written.
-func GenerateInstallScript(baseDistro string, packages map[string][]string, automationData *automation.AutomationData, scriptPath string) error {
+func GenerateInstallScript(baseDistro string, packages map[string][]string, automationData *domain.AutomationData, scriptPath string) error {
 	f, err := os.Create(scriptPath)
 	if err != nil {
 		return err
@@ -117,13 +117,13 @@ func GenerateInstallScript(baseDistro string, packages map[string][]string, auto
 	if automationData != nil {
 		am := automation.NewAutomationManager()
 		automationCommands := am.GenerateRestorationCommands(automationData)
-		
+
 		if len(automationCommands) > 0 {
 			_, err = fmt.Fprintln(f, "\necho 'Restoring automation files...'")
 			if err != nil {
 				return err
 			}
-			
+
 			for _, cmd := range automationCommands {
 				_, err = fmt.Fprintf(f, "%s\n", cmd)
 				if err != nil {


### PR DESCRIPTION
### What this PR does

Moves automation detection, backup, and restore logic into the new `internal/core/automation` layer to better align with the project’s layered architecture and clearly separate responsibilities.

### Changes
- Created new package `internal/core/automation`
- Moved automation detection logic:
  - `automation/detect.go` → `internal/core/automation/scanner.go`
  - Updated implementation to build and use `domain.AutomationData`
- Moved automation backup logic:
  - `automation/backup.go` → `internal/core/automation/backup.go`
  - Kept the `BackupAutomation(data, *tar.Writer)` signature unchanged, preserving its strategy-style interface
- Refactored restore-related logic:
  - Extracted `GenerateRestorationCommands` into `internal/core/automation/restore.go`
  - Clearly separated backup logic from restore logic
- Updated package names and imports to reflect the new core structure

Closes #14 