### PR TITLE
refactor(ui): move run command and backup helpers to internal/ui (#18)

### DIFF
--- a/internal/ui/backup_integration.go
+++ b/internal/ui/backup_integration.go
@@ -1,4 +1,4 @@
-package system
+package ui
 
 import (
 	"bufio"

--- a/internal/ui/runner.go
+++ b/internal/ui/runner.go
@@ -1,4 +1,4 @@
-package system
+package ui
 
 import (
 	"bufio"

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/mdgspace/sysreplicate/system"
+	"github.com/mdgspace/sysreplicate/internal/ui"
 )
 // main is the entry point for the program.
 func main() {
-	system.Run()
+	ui.Run()
 }


### PR DESCRIPTION
## What this PR does
Moves the run command logic and backup integration helpers into the `internal/ui` namespace to better reflect their responsibility now that `run` depends on the TUI layer.

## Changes
- Moved `run.go` → `internal/ui/run.go` (renamed where appropriate)
- Moved `backup_integration.go` → `internal/ui/backup_integration.go`
- Updated package declarations to `ui`
- Updated imports across the project to reference `internal/ui`
- Ensured `go.mod` / `go.sum` remain tidy

## Result
- Clearer separation of UI-related logic
- Project structure better aligned with current architecture
- No change in runtime behavior