### PR TITLE
fix: systemd unit panic, fd leak, key discovery abort

### DIFF
--- a/internal/core/automation/scanner.go
+++ b/internal/core/automation/scanner.go
@@ -33,6 +33,9 @@ func (am *AutomationManager) detectSystemDUnits() ([]SystemDUnit, []SystemDUnit,
 		}
 
 		ext := filepath.Ext(path)
+		if len(ext) <= 1 {
+			return nil
+		}
 		unitName := filepath.Base(path)
 
 		content, err := am.readFileContent(path)

--- a/internal/core/backup/dotfile_scanner.go
+++ b/internal/core/backup/dotfile_scanner.go
@@ -13,6 +13,9 @@ func expandHome(path string) string {
 	if strings.HasPrefix(path, "~") {
 		home, err := os.UserHomeDir()
 		if err == nil {
+			if len(path) == 1 {
+				return home
+			}
 			return filepath.Join(home, path[2:])
 		}
 	}

--- a/internal/core/backup/search.go
+++ b/internal/core/backup/search.go
@@ -1,116 +1,117 @@
 package backup
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/mdgspace/sysreplicate/internal/domain"
+	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
 // any saved keylcoation
 type KeyLocation struct {
-        Path        string
+	Path string
 
-        Type        string // "ssh", "gpg", "custom" strongs can be stored
-        
-        Files       []string
-        
-        IsDirectory bool
+	Type string // "ssh", "gpg", "custom" strongs can be stored
+
+	Files []string
+
+	IsDirectory bool
 }
 
 // searches for keys in standard locations
 func searchStandardLocations() ([]KeyLocation, error) {
-    var locations []KeyLocation
-    homeDir, err := os.UserHomeDir()
-    if err != nil {
-        return nil, err
-    }
+	var locations []KeyLocation
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
 
-    for _, location := range domain.StandardKeyLocations {
-        // replace ~operator with actual home directory
-        fullPath := strings.Replace(location, "~", homeDir, 1)
-        
-        if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-            continue // skip on dir invalid
-        }
+	for _, location := range domain.StandardKeyLocations {
+		// replace ~operator with actual home directory
+		fullPath := strings.Replace(location, "~", homeDir, 1)
 
-        
-        keyType := determineKeyType(fullPath)
-        files, err := discoverKeyFiles(fullPath)
-        if err != nil {
-            continue
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			continue // skip on dir invalid
+		}
 
-        }
+		keyType := determineKeyType(fullPath)
+		files, err := discoverKeyFiles(fullPath)
+		if err != nil {
+			continue
 
-        if len(files) > 0 {
-            locations = append(locations, KeyLocation{
-                
-                Path:        fullPath,
-                Type:        keyType,
-                Files:       files,
-                IsDirectory: true,
-            })
-        }
-    }
+		}
 
-    return locations, nil
+		if len(files) > 0 {
+			locations = append(locations, KeyLocation{
+
+				Path:        fullPath,
+				Type:        keyType,
+				Files:       files,
+				IsDirectory: true,
+			})
+		}
+	}
+
+	return locations, nil
 }
 
 // determineKeyType identifies the type of keys based on directory path
 func determineKeyType(path string) string {
-    if strings.Contains(path, ".ssh") {
-        return "ssh"
-    }
-    if strings.Contains(path, ".gnupg") {
-        return "gpg"
-    }
-    return "custom"
+	if strings.Contains(path, ".ssh") {
+		return "ssh"
+	}
+	if strings.Contains(path, ".gnupg") {
+		return "gpg"
+	}
+	return "custom"
 }
 
 // discoverKeyFiles finds all key files in a directory
 func discoverKeyFiles(dirPath string) ([]string, error) {
-    var keyFiles []string
-    
-    err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
-        
-        if !info.IsDir() && isKeyFile(path, info) {
-            keyFiles = append(keyFiles, path)
-        }
-        
-        return nil
-    })
-    
-    return keyFiles, err
+	var keyFiles []string
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Printf("Warning: skipping %s: %v", path, err)
+			return nil
+		}
+
+		if !info.IsDir() && isKeyFile(path, info) {
+			keyFiles = append(keyFiles, path)
+		}
+
+		return nil
+	})
+
+	return keyFiles, err
 }
 
 // isKeyFile determines if a file is likely a key file
 func isKeyFile(path string, info os.FileInfo) bool {
-    name := info.Name()
-    
-    // check SSH 
-    for _, pattern := range domain.SshPatterns {
-        if strings.Contains(name, pattern) {
-            return true
-        }
-    }
-    
-    // check GPG
-    for _, pattern := range domain.GpgPatterns {
-        if strings.Contains(name, pattern) {
-            return true
-        }
-    }
-    
-    // check for private key extensions - more can be added
-    if strings.HasSuffix(name, ".pub") || 
-       strings.HasSuffix(name, ".pem") || 
-       strings.HasSuffix(name, ".key") {
-        return true
-    }
-    
-    return false
+	name := info.Name()
+
+	// check SSH
+	for _, pattern := range domain.SshPatterns {
+		if strings.Contains(name, pattern) {
+			return true
+		}
+	}
+
+	// check GPG
+	for _, pattern := range domain.GpgPatterns {
+		if strings.Contains(name, pattern) {
+			return true
+		}
+	}
+
+	// check for private key extensions - more can be added
+	if strings.HasSuffix(name, ".pub") ||
+		strings.HasSuffix(name, ".pem") ||
+		strings.HasSuffix(name, ".key") {
+		return true
+	}
+
+	return false
 }

--- a/internal/core/generator/archive.go
+++ b/internal/core/generator/archive.go
@@ -87,17 +87,25 @@ func CreateDotfilesBackupTarball(meta *domain.BackupMetadata, tarballPath string
 		if f.IsDir {
 			continue
 		}
-		file, err := os.Open(f.Path)
-		if err != nil {
+
+		if err := func() error {
+			file, err := os.Open(f.Path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			info, _ := file.Stat()
+			hdr, _ := tar.FileInfoHeader(info, "")
+			hdr.Name = f.RealPath
+			if err := tarWriter.WriteHeader(hdr); err != nil {
+				return err
+			}
+			_, err = io.Copy(tarWriter, file)
+			return err
+		}(); err != nil {
 			continue
 		}
-		defer file.Close()
-
-		info, _ := file.Stat()
-		hdr, _ := tar.FileInfoHeader(info, "")
-		hdr.Name = f.RealPath
-		tarWriter.WriteHeader(hdr)
-		io.Copy(tarWriter, file)
 	}
 
 	return nil


### PR DESCRIPTION
Four crash/data-loss bugs that can hit real users.

- **Extensionless systemd unit panic**: `ext[1:]` on units without
  extensions crashed the scanner. Now guards with `len(ext) <= 1`.
- **File descriptor leak in dotfile tarball**: `defer file.Close()` inside
  a loop accumulated open handles. Replaced with an anonymous function
  wrapper that closes immediately.
- **Bare `~` panic**: `path[2:]` on a 1-char path crashed `expandHome`.
  Now returns home directory directly for bare `~`.
- **Key discovery aborted by permission errors**: `filepath.Walk` stopped
  entire directory scans on the first inaccessible file. Now skips and
  logs warnings instead.