### PR TITLE
Enhance distro support and improve ID_LIKE parsing

### DIFF
--- a/internal/core/generator/scripts.go
+++ b/internal/core/generator/scripts.go
@@ -32,6 +32,14 @@ func GenerateInstallScript(baseDistro string, packages map[string][]string, auto
 		officialInstallCmd = domain.RhelInstallCmd
 	case "void":
 		officialInstallCmd = domain.VoidInstallCmd
+	case "opensuse":
+		officialInstallCmd = domain.OpenSUSEInstallCmd
+	case "alpine":
+		officialInstallCmd = domain.AlpineInstallCmd
+	case "nixos":
+		officialInstallCmd = domain.NixOSInstallCmd
+	case "gentoo":
+		officialInstallCmd = domain.GentooInstallCmd
 	default:
 		_, _ = fmt.Fprintln(f, "echo 'Unsupported distro for script generation.'")
 		return nil
@@ -48,7 +56,11 @@ func GenerateInstallScript(baseDistro string, packages map[string][]string, auto
 				if pkg == "" {
 					continue
 				}
-				_, err = fmt.Fprintf(f, "%s %s || true\n", officialInstallCmd, pkg)
+				if baseDistro == "nixos" {
+					_, err = fmt.Fprintf(f, "%s nixpkgs.%s || true\n", officialInstallCmd, pkg)
+				} else {
+					_, err = fmt.Fprintf(f, "%s %s || true\n", officialInstallCmd, pkg)
+				}
 				if err != nil {
 					return err
 				}

--- a/internal/domain/constants.go
+++ b/internal/domain/constants.go
@@ -14,10 +14,14 @@ const (
 	CronDDirPath             = "/etc/cron.d"
 	UnifiedTarballBasePath   = "dist/unified-backup-%s.tar.gz"
 
-	DebianInstallCmd = "sudo apt-get install -y"
-	ArchInstallCmd   = "sudo pacman -S --noconfirm"
-	RhelInstallCmd   = "sudo dnf install -y"
-	VoidInstallCmd   = "sudo xbps-install -y"
+	DebianInstallCmd     = "sudo apt-get install -y"
+	ArchInstallCmd       = "sudo pacman -S --noconfirm"
+	RhelInstallCmd       = "sudo dnf install -y"
+	VoidInstallCmd       = "sudo xbps-install -y"
+	OpenSUSEInstallCmd   = "sudo zypper install -y"
+	AlpineInstallCmd     = "sudo apk add"
+	NixOSInstallCmd      = "nix-env -iA nixpkgs."
+	GentooInstallCmd     = "sudo emerge -q"
 
 	DebianFetchCmd = `dpkg-query -W -f='${Package}\n' | sort > /tmp/all.txt
 apt-mark showmanual | sort > /tmp/manual.txt
@@ -27,6 +31,10 @@ rm /tmp/all.txt /tmp/manual.txt`
 	ArchYayFetchCmd      = `pacman -Qem | cut -d' ' -f1`
 	RhelFetchCmd         = "rpm -qa"
 	VoidFetchCmd         = "xbps-query -l"
+	OpenSUSEFetchCmd     = "zypper search --installed-only | tail -n +3 | awk '{print $2}'"
+	AlpineFetchCmd       = "apk info -v"
+	NixOSFetchCmd        = "nix-env -q"
+	GentooFetchCmd       = "ls /var/db/pkg/*/* | xargs -n1 basename"
 
 	FlatpakFetchCmd = "flatpak list --app --columns=origin,application"
 	SnapFetchCmd    = "snap list | awk 'NR>1 {print $1}'"

--- a/internal/domain/constants.go
+++ b/internal/domain/constants.go
@@ -20,7 +20,7 @@ const (
 	VoidInstallCmd       = "sudo xbps-install -y"
 	OpenSUSEInstallCmd   = "sudo zypper install -y"
 	AlpineInstallCmd     = "sudo apk add"
-	NixOSInstallCmd      = "nix-env -iA nixpkgs."
+	NixOSInstallCmd      = "nix-env -iA"
 	GentooInstallCmd     = "sudo emerge -q"
 
 	DebianFetchCmd = `dpkg-query -W -f='${Package}\n' | sort > /tmp/all.txt

--- a/internal/platform/distro.go
+++ b/internal/platform/distro.go
@@ -3,24 +3,107 @@ package platform
 import (
 	"os"
 	"strings"
+
 	"github.com/mdgspace/sysreplicate/internal/domain"
 )
 
-// DetectDistro returns the distro and base distro.
+var knownDistros = map[string]string{
+	"debian":       "debian",
+	"ubuntu":       "debian",
+	"linuxmint":    "debian",
+	"pop":          "debian",
+	"arch":         "arch",
+	"manjaro":      "arch",
+	"endeavouros":  "arch",
+	"rhel":         "rhel",
+	"fedora":       "fedora",
+	"centos":       "rhel",
+	"rocky":        "rhel",
+	"alma":         "rhel",
+	"void":         "void",
+	"opensuse":     "opensuse",
+	"opensuse-leap": "opensuse",
+	"opensuse-tumbleweed": "opensuse",
+	"suse":         "opensuse",
+	"alpine":       "alpine",
+	"nixos":        "nixos",
+	"gentoo":       "gentoo",
+}
+
+func normalizeDistro(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func resolveBaseDistro(candidates []string) string {
+	for _, c := range candidates {
+		normalized := normalizeDistro(c)
+		if base, ok := knownDistros[normalized]; ok {
+			return base
+		}
+	}
+	return ""
+}
+
+func extractField(data, prefix string) string {
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			return strings.Trim(strings.SplitN(line, "=", 2)[1], `"`)
+		}
+	}
+	return ""
+}
+
+func readOSRelease() (string, error) {
+	paths := []string{domain.OsReleasePath, "/etc/lsb-release", "/etc/issue"}
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		return string(data), nil
+	}
+	return "", os.ErrNotExist
+}
+
+// DetectDistro returns the distro name and the base distro for package management.
 func DetectDistro() (string, string) {
-	data, err := os.ReadFile(domain.OsReleasePath)
+	data, err := readOSRelease()
 	if err != nil {
 		return "unknown", "unknown"
 	}
-	var distro, baseDistro string
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "ID=") {
-			distro = strings.Trim(strings.SplitN(line, "=", 2)[1], `"`)
-		}
-		if strings.HasPrefix(line, "ID_LIKE=") {
-			baseDistro = strings.Trim(strings.SplitN(line, "=", 2)[1], `"`)
-		}
+
+	distro := normalizeDistro(extractField(data, "ID="))
+	idLike := extractField(data, "ID_LIKE=")
+
+	candidates := []string{distro}
+	candidates = append(candidates, strings.Fields(idLike)...)
+
+	baseDistro := resolveBaseDistro(candidates)
+	if baseDistro == "" {
+		baseDistro = "unknown"
 	}
+
 	return distro, baseDistro
+}
+
+func IsImmutableDistro() bool {
+	data, err := readOSRelease()
+	if err != nil {
+		return false
+	}
+
+	id := normalizeDistro(extractField(data, "ID="))
+	variant := normalizeDistro(extractField(data, "VARIANT_ID="))
+
+	switch {
+	case variant == "silverblue" || variant == "kinoite":
+		return true
+	case strings.Contains(id, "steamos"):
+		return true
+	case strings.Contains(id, "opensuse-microos"):
+		return true
+	}
+
+	return false
 }

--- a/internal/platform/packages.go
+++ b/internal/platform/packages.go
@@ -24,6 +24,18 @@ func FetchPackages(baseDistro string) map[string][]string {
 
     case "void":
         cmds["official_packages"] = exec.Command("sh", "-c", domain.VoidFetchCmd)
+
+    case "opensuse":
+        cmds["official_packages"] = exec.Command("sh", "-c", domain.OpenSUSEFetchCmd)
+
+    case "alpine":
+        cmds["official_packages"] = exec.Command("sh", "-c", domain.AlpineFetchCmd)
+
+    case "nixos":
+        cmds["official_packages"] = exec.Command("sh", "-c", domain.NixOSFetchCmd)
+
+    case "gentoo":
+        cmds["official_packages"] = exec.Command("sh", "-c", domain.GentooFetchCmd)
     default:
         log.Println("Unsupported distro for native package manager detection")
     }

--- a/internal/ui/backup_integration.go
+++ b/internal/ui/backup_integration.go
@@ -42,6 +42,14 @@ func RunUnifiedBackup() {
 		return
 	}
 
+	if platform.IsImmutableDistro() {
+		fmt.Println()
+		fmt.Println("WARNING: Immutable distro detected (Silverblue/Kinoite/SteamOS/MicroOS).")
+		fmt.Println("  Standard package install commands do not apply. Use rpm-ostree or")
+		fmt.Println("  transactional-update manually to layer packages on immutable systems.")
+		fmt.Println()
+	}
+
 	ubm := backup.NewUnifiedBackupManager()
 
 	fmt.Println("\nOptional: Add custom key locations")


### PR DESCRIPTION
This pull request adds comprehensive support for additional Linux distributions to the package management detection and script generation logic. It improves the detection of the operating system and its base distribution, adds install and fetch commands for new distros, and introduces user warnings for immutable distributions. These changes enhance compatibility and robustness for a wider variety of Linux environments.

**Extended distribution support:**

* Added install and fetch command support for `opensuse`, `alpine`, `nixos`, and `gentoo` in `internal/domain/constants.go`, and integrated these into the script generation logic in `internal/core/generator/scripts.go` and package fetching in `internal/platform/packages.go`. [[1]](diffhunk://#diff-dd5b2d5a0a69a8c685ab1316151256f49640cd4103e32fad294cba64001768c3R21-R24) [[2]](diffhunk://#diff-dd5b2d5a0a69a8c685ab1316151256f49640cd4103e32fad294cba64001768c3R34-R37) [[3]](diffhunk://#diff-ff5457370eda744296ab0236c9d26f411d1913cbe2d00125d2758e4315e16557R35-R42) [[4]](diffhunk://#diff-ff5457370eda744296ab0236c9d26f411d1913cbe2d00125d2758e4315e16557R59-R63) [[5]](diffhunk://#diff-0934cf1b3fcc4fd8fc4d705e02212797f45784b4701fd27419e5b846c2a1a1cdR27-R38)

**Improved distro detection:**

* Refactored `DetectDistro` in `internal/platform/distro.go` to normalize and map distro names more robustly, using `/etc/os-release`, `/etc/lsb-release`, or `/etc/issue`, and to better resolve base distros.

**Immutable distro handling:**

* Added an `IsImmutableDistro` function to detect immutable distributions (e.g., Silverblue, Kinoite, SteamOS, MicroOS) and display a warning to users in the backup integration UI, advising them to use the appropriate package layering tools. [[1]](diffhunk://#diff-cb459f6652ceb33f59d6d98a1558d649372ee12e471af957c0a0d355d7f7b5d2R6-R108) [[2]](diffhunk://#diff-2114d8e149d6c691d804591fbbb688b1c295310b3efff36743ffad51aae4bca5R45-R52)

**NixOS-specific logic:**

* Updated the install script generator to use the correct `nix-env` syntax for NixOS packages.

These changes collectively improve the tool’s ability to function correctly across a much broader set of Linux distributions.